### PR TITLE
Add (public) to send_op_return

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -212,7 +212,7 @@
     "send_invalid_address": "Invalid address",
     "send_label": "Label (optional)",
     "send_oops": "Something went wrong, please try again",
-    "send_op_return": "Metadata Message",
+    "send_op_return": "Metadata Message (public)",
     "send_qr": "QR-Code",
     "send_to": " to ",
     "send_total": "Total $amount $letter_code",


### PR DESCRIPTION
Add (public) to send_op_return so noobs don't post private data between sender and receiver on the blockchain.