### PR TITLE
Fix building Android targets on a Linux host platform

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 35
-    ndkVersion "26.3.11579264"
+    ndkVersion "27.2.12479018"
     namespace "com.coinerella.peercoin"
 
     sourceSets {
@@ -58,19 +58,23 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-   signingConfigs {
-       release {
-           keyAlias keystoreProperties['keyAlias']
-           keyPassword keystoreProperties['keyPassword']
-           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
-           storePassword keystoreProperties['storePassword']
-       }
-   }
-   buildTypes {
-       release {
-           signingConfig signingConfigs.release
-       }
-   }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
 }
 
 flutter {
@@ -79,5 +83,5 @@ flutter {
 
 dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.10.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -517,10 +517,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "407929c60becc36c3fb2a69b3f51e348f26f806a"
+      resolved-ref: "42949f2d7b4f5d8f5d7771d40d5497517da0a884"
       url: "https://github.com/ced1check/flutter_logs"
     source: git
-    version: "2.1.12"
+    version: "2.2.1"
   flutter_markdown:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This allows builds to be done on Debian. Hopefully the updated configuration doesn't break builds on macOS.