### PR TITLE
Clarify meaning of threshold

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -608,7 +608,7 @@
   "roast_wallet_request_dkg_name": "Name",
   "roast_wallet_request_dkg_description": "Description",
   "roast_wallet_request_dkg_threshold": "Threshold",
-  "roast_wallet_request_dkg_threshold_hint": "Number of required signatures",
+  "roast_wallet_request_dkg_threshold_hint": "Number of required accepting participants",
   "roast_wallet_request_dkg_threshold_empty_error": "Please enter a threshold",
   "roast_wallet_request_dkg_threshold_not_number_error": "Threshold must be a number",
   "roast_wallet_request_dkg_threshold_too_small_error": "Threshold must be at least 2",


### PR DESCRIPTION
The threshold is for how many participants must accept a signatures request and provide signature shares. ROAST/FROST is not a multi-signature scheme, so saying "signatures" is wrong and could cause confusion.

An alternative might be "Number of required signature shares", but mentioning "accepting participants" is perhaps clearer.