### PR TITLE
Bulgaria adopted the euro as its official currency on January 1, 2026…

### DIFF
--- a/assets/translations/ar.json
+++ b/assets/translations/ar.json
@@ -356,7 +356,6 @@
     "app_settings_language_search": "لغة البحث",
     "currency_AZN": "مانات أذربيجاني",
     "currency_BAM": "مارك البوسنة والهرسك قابل للتحويل",
-    "currency_BGN": "ليف بلغاري",
     "currency_BHD": "دينار بحريني",
     "currency_BIF": "فرنك بوروندي",
     "currency_BND": "دولار بروني",

--- a/assets/translations/da.json
+++ b/assets/translations/da.json
@@ -373,7 +373,6 @@
     "currency_AMD": "Armenske dram",
     "currency_AOA": "Angolansk kwanza",
     "currency_AZN": "Aserbajdsjansk manat",
-    "currency_BGN": "Bulgarsk lev",
     "currency_BHD": "Bahrainsk dinar",
     "currency_BIF": "Burundisk franc",
     "currency_BND": "Bruneisk dollar",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -129,7 +129,6 @@
   "currency_BAM": "Bosnia and Herzegovina Convertible Mark",
   "currency_BBD": "Barbadian or Bajan Dollar",
   "currency_BDT": "Bangladeshi Taka",
-  "currency_BGN": "Bulgarian Lev",
   "currency_BHD": "Bahraini Dinar",
   "currency_BIF": "Burundian Franc",
   "currency_BMD": "Bermudian Dollar",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -389,7 +389,6 @@
     "wallet_scanner_message_scan_finished": "escaneo finalizado para $coinName en $accountNumber",
     "wallet_scanner_message_scan_failed": "el escaneo falló para $coinName en $accountNumber ($e)",
     "currency_BAM": "Marco Convertible de Bosnia y Herzegovina",
-    "currency_BGN": "Lev Búlgaro",
     "currency_BHD": "Dinar Bahreiní",
     "currency_BIF": "Franco Burundés",
     "currency_BND": "Dólar de Brunei",

--- a/assets/translations/hi.json
+++ b/assets/translations/hi.json
@@ -400,7 +400,6 @@
     "currency_ALL": "अल्बानियाई लेक",
     "currency_AOA": "अंगोलन क्वान्ज़ा",
     "currency_AZN": "अज़रबैजानी मनत",
-    "currency_BGN": "बल्गेरियाई लेव",
     "currency_BHD": "बहरीन दीनार",
     "currency_BIF": "बुरुंडियन फ़्रैंक",
     "currency_BND": "ब्रुनेई डॉलर",

--- a/assets/translations/hr.json
+++ b/assets/translations/hr.json
@@ -348,7 +348,6 @@
     "about_donate_button": "Donirajte PPC",
     "app_settings_delete": "Izbriši račun",
     "app_settings_experimental_feature_roast": "ROAST Grupe",
-    "currency_BGN": "Bugarski Lev",
     "currency_CAD": "Kanadski Dolar",
     "currency_CLP": "Čileanski Peso",
     "app_settings_language_search": "Nađi jezik",

--- a/assets/translations/is.json
+++ b/assets/translations/is.json
@@ -449,7 +449,6 @@
     "currency_XOF": "Vestur-afrískur CFA-franki",
     "currency_YER": "Jemenskt ríal",
     "currency_ZWL": "Zimbabwískur dalur",
-    "currency_BGN": "Búlgarsk lev",
     "currency_BHD": "Bareinsk dinar",
     "currency_STN": "Saó Tóme og Prinsípe-dobra",
     "currency_ZMW": "Sambísk kvaka",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -403,7 +403,6 @@
     "currency_AOA": "アンゴラ・クワンザ",
     "currency_AZN": "アゼルバイジャン マナト",
     "currency_BAM": "ボスニア兌換マルク",
-    "currency_BGN": "ブルガリアレフ",
     "currency_BIF": "ブルンジフラン",
     "currency_BND": "ブルネイドル",
     "currency_BOB": "ボリビアのボリビアーノ",

--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -357,7 +357,6 @@
     "currency_AOA": "앙골라 콴자",
     "currency_AZN": "아제르바이잔 마나트",
     "currency_BAM": "보스니아 컨버터블 마크",
-    "currency_BGN": "불가리아 레프",
     "currency_BHD": "바레인 디나르",
     "currency_BND": "브루나이 달러",
     "currency_BOB": "볼리비아 볼리비아노",

--- a/assets/translations/nb_NO.json
+++ b/assets/translations/nb_NO.json
@@ -357,7 +357,6 @@
     "currency_AOA": "Angolansk kwanza",
     "currency_AZN": "Aserbajdsjansk manat",
     "currency_BAM": "Konvertibilna mark",
-    "currency_BGN": "Bulgarsk lev",
     "currency_BHD": "Bahrainsk dinar",
     "currency_BIF": "Burundisk franc",
     "currency_BND": "Bruneisk dollar",

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -402,7 +402,6 @@
     "currency_AOA": "Kwanza Angolano",
     "currency_AZN": "Manat Azerbaijano",
     "currency_BAM": "Marco Convertível da Bósnia",
-    "currency_BGN": "Lev Búlgaro",
     "currency_BHD": "Dinar Bahraini",
     "currency_BIF": "Franco Burundiano",
     "currency_BOB": "Boliviano Boliviano",

--- a/assets/translations/ro.json
+++ b/assets/translations/ro.json
@@ -373,7 +373,6 @@
     "currency_AZN": "Manat Azerbaijan",
     "currency_BAM": "Marcă Convertibilă Bosniană",
     "currency_BBD": "Dollar Barbadian or Bajanian",
-    "currency_BGN": "Leva Bulgară",
     "currency_BHD": "Dinar Bahrainian",
     "currency_BIF": "Franc Burundian",
     "currency_BMD": "Dollar Bermudian",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -419,7 +419,6 @@
     "sign_transaction_confirmation_transaction_id": "ID транзакции",
     "currency_AWG": "Арубанский Флорин",
     "currency_AZN": "Азербайджанский Манат",
-    "currency_BGN": "Болгарский Лев",
     "currency_BIF": "Бурундийский Франк",
     "currency_GEL": "Грузинский Лари",
     "currency_GHS": "Ганский Седи",

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -350,7 +350,6 @@
     "app_settings_wallet_order": "Ordning av Plånböcker",
     "app_settings_price_feed_search": "Sök efter valutakod",
     "app_settings_language_search": "Sök efter språk",
-    "currency_BGN": "Bulgariska lev",
     "currency_BWP": "Botswanasiska pula",
     "currency_CDF": "Kongolesiska franc",
     "currency_CHF": "Schweiziska franc",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -387,7 +387,6 @@
     "currency_AZN": "Azerbaycan Manatı",
     "currency_AMD": "Ermeni Dramı",
     "currency_AOA": "Angol Kwanza",
-    "currency_BGN": "Bulgar Levası",
     "currency_DOP": "Dominik Pesosu",
     "currency_GNF": "Gine Frangı",
     "currency_BAM": "Bosna Hersek Konvertibl Mark",

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -356,7 +356,6 @@
     "currency_AOA": "Kwanza Angola",
     "currency_AZN": "Manat Azerbaijan",
     "currency_BAM": "Mark Bosnia-Herzegovina",
-    "currency_BGN": "Lev Bulgaria",
     "currency_BHD": "Dinar Bahrain",
     "currency_BIF": "Franc Burundi",
     "currency_BND": "Đô la Brunei",

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -355,7 +355,6 @@
     "currency_AMD": "亚美尼亚德拉姆",
     "currency_AOA": "安哥拉宽扎",
     "currency_AZN": "阿塞拜疆马纳特",
-    "currency_BGN": "保加利亚列弗",
     "currency_BHD": "巴林第纳尔",
     "currency_BIF": "布隆迪法郎",
     "currency_BND": "文莱元",

--- a/assets/translations/zh_Hant.json
+++ b/assets/translations/zh_Hant.json
@@ -356,7 +356,6 @@
     "currency_AOA": "安哥拉寬扎",
     "currency_AZN": "阿塞拜疆馬納特",
     "currency_BAM": "波斯尼亞可兌換馬克",
-    "currency_BGN": "保加利亞列弗",
     "currency_BHD": "巴林第納爾",
     "currency_BIF": "布隆迪法郎",
     "currency_BOB": "玻利維亞 玻利維亞諾",

--- a/lib/tools/price_ticker.dart
+++ b/lib/tools/price_ticker.dart
@@ -41,7 +41,6 @@ class PriceTicker {
     'BAM': 'KM',
     'BBD': '\$',
     'BDT': '৳',
-    'BGN': 'лв',
     'BHD': 'ب.د',
     'BIF': 'FBu',
     'BMD': '\$',


### PR DESCRIPTION
…, becoming the 21st member of the eurozone. This transition replaced the Bulgarian lev.  https://www.ecb.europa.eu/press/pr/date/2026/html/ecb.pr260101~c830245e42.en.html